### PR TITLE
Sticking Chat Header and Adjusting Margin

### DIFF
--- a/src/components/TextBar/index.tsx
+++ b/src/components/TextBar/index.tsx
@@ -3,6 +3,7 @@ import { Box, Button, Input } from "@chakra-ui/react";
 import { MdSend } from "react-icons/md";
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import "styles/global.css";
 
 
 const TextBar = (props: any) => {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -98,6 +98,9 @@ a {
   position: relative;
   font-family: Mulish-medium;
 }
+.Toastify__toast-container{
+  top: 50px;
+}
 @media screen and (max-width: 768px) {
   .chat-body {
     width: 100%;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -89,7 +89,8 @@ a {
 }
 .chat-body {
   /* opacity: 0; */
-  width: 50%;
+  width: 90%;
+  top: 20px;
   background-color: #ffffff;
   padding: 0px 20px;
   padding-bottom: 98px !important;
@@ -121,6 +122,7 @@ a {
   margin-top: 1rem;
 }
 .chat-choices-container {
+  margin-left: 15px;
   display: inline-flex;
   flex-wrap: wrap;
 }
@@ -178,6 +180,9 @@ a {
   background-color: #000080;
   background-blend-mode: multiply;
   color: white;
+  z-index: 5;
+  position: fixed;
+  width: 100%;
 }
 .chat__header--info {
   flex: 1;


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/Samagra-Development/uci-pwa/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

This PR Contains changes to UI for the chat header and the chat container where the header was getting scrolled with more messages so it was sticked to top just like other standard chat platforms and the extra margin from the chat container was adjusted for better appearance.
Fixes #10 

### Changes


https://user-images.githubusercontent.com/79367883/170105772-2ba7f1ff-bb99-4955-8b7b-9b4b20a3d560.mp4



## How to test

-> Open the Chat Window.
-> Send enough messages to fill whole screen height.
-> You will see the header being sticked against the screen.
-> Right Margin space is adjusted

Please consider using the closing keyword if the pull request is proposed to
fix an issue already created in the repository
(https://help.github.com/articles/closing-issues-using-keywords/)